### PR TITLE
Fix/account lookup

### DIFF
--- a/src/controllers/parties-controller.ts
+++ b/src/controllers/parties-controller.ts
@@ -4,11 +4,11 @@ import { PartiesTypeIDPutResponse } from 'types/mojaloop'
 export async function update (request: Request, h: ResponseToolkit): Promise<ResponseObject> {
   try {
     request.server.app.logger.info('Received PUT parties. headers: ' + JSON.stringify(request.headers) + ' payload: ' + JSON.stringify(request.payload))
-    const transactionRequestId = request.headers.id
     const fspId = (request.payload as PartiesTypeIDPutResponse).party.partyIdInfo.fspId
     if (!fspId) {
       throw new Error('No fspId')
     }
+    const { transactionRequestId } = await request.server.app.transactionsService.getByPayerMsisdn(request.params.ID)
     const transaction = await request.server.app.transactionsService.updatePayerFspId(transactionRequestId, 'transactionRequestId', fspId)
 
     await request.server.app.transactionsService.sendToMojaHub(transaction)

--- a/src/services/transactions-service.ts
+++ b/src/services/transactions-service.ts
@@ -88,6 +88,7 @@ export interface TransactionsService {
   updateTransactionId (id: string, idType: 'transactionId' | 'transactionRequestId', fspId: string): Promise<Transaction>;
   updateState (id: string, idType: 'transactionId' | 'transactionRequestId', state: string): Promise<Transaction>;
   sendToMojaHub (request: TransactionRequest): Promise<void>;
+  getByPayerMsisdn (msisdn: string): Promise<Transaction>;
 }
 export class KnexTransactionsService implements TransactionsService {
   constructor (private _knex: Knex, private _client: AxiosInstance) {
@@ -232,5 +233,18 @@ export class KnexTransactionsService implements TransactionsService {
       transactionType: request.transactionType
     }
     await this._client.post('/transactionRequests', transactionRequest, { headers })
+  }
+
+  async getByPayerMsisdn (msisdn: string): Promise<Transaction> {
+    const transaction = await this._knex('transactionParties').select('transactionParties.transactionRequestId').where('identifierValue', msisdn)
+      .leftJoin('transactions', function () {
+        this.on('transactions.transactionRequestId', '=', 'transactionParties.transactionRequestId')
+      }).where('transactions.state', TransactionState.transactionReceived).orderBy('transactions.created_at', 'desc').first()
+
+    if (!transaction) {
+      throw new Error('No transaction found.')
+    }
+
+    return this.get(transaction.transactionRequestId, 'transactionRequestId')
   }
 }

--- a/test/api/parties.test.ts
+++ b/test/api/parties.test.ts
@@ -35,7 +35,9 @@ describe('Parties API', function () {
   beforeEach(async () => {
     await knex.migrate.latest()
     // this is the iso0100 message first being sent
-    const iso0100 = ISO0100Factory.build()
+    const iso0100 = ISO0100Factory.build({
+      102: '0821234567'
+    })
     const response = await adaptor.inject({
       method: 'POST',
       url: '/iso8583/transactionRequests',
@@ -53,26 +55,40 @@ describe('Parties API', function () {
   })
 
   test('updates the fspId of the payer in the transaction request', async () => {
-    const putPartiesResponse = PartiesPutResponseFactory.build()
+    const putPartiesResponse = PartiesPutResponseFactory.build({
+      party: {
+        partyIdInfo: {
+          partyIdType: 'MSISDN',
+          partyIdentifier: '0821234567',
+          fspId: 'mojawallet'
+        }
+      }
+    })
 
     const response = await adaptor.inject({
       method: 'PUT',
-      headers: { ID: '123' },
       payload: putPartiesResponse,
       url: `/parties/MSISDN/${putPartiesResponse.party.partyIdInfo.partyIdentifier}`
     })
 
     expect(response.statusCode).toBe(200)
     const transaction = await services.transactionsService.get('123', 'transactionRequestId')
-    expect(transaction.payer.fspId).toBe(putPartiesResponse.party.partyIdInfo.fspId)
+    expect(transaction.payer.fspId).toBe('mojawallet')
   })
 
   test('makes a transaction request to the Moja switch', async () => {
-    const putPartiesResponse = PartiesPutResponseFactory.build()
+    const putPartiesResponse = PartiesPutResponseFactory.build({
+      party: {
+        partyIdInfo: {
+          partyIdType: 'MSISDN',
+          partyIdentifier: '0821234567',
+          fspId: 'mojawallet'
+        }
+      }
+    })
 
     const response = await adaptor.inject({
       method: 'PUT',
-      headers: { ID: '123' },
       payload: putPartiesResponse,
       url: `/parties/MSISDN/${putPartiesResponse.party.partyIdInfo.partyIdentifier}`
     })

--- a/test/factories/transaction-requests.ts
+++ b/test/factories/transaction-requests.ts
@@ -23,7 +23,8 @@ export const TransactionRequestFactory = Factory.define<TransactionRequest>('Tra
   payee: {
     partyIdInfo: {
       partyIdType: 'MSISDN',
-      partyIdentifier: '12345678'
+      partyIdentifier: '12345678',
+      fspId: 'adaptor'
     }
   },
   payer: {


### PR DESCRIPTION
Don't use `id` in header for parties put response to find transaction. Instead, find most recent transaction with `transactionReceived` state and payer msisdn.